### PR TITLE
Extend servant-docs to support content types

### DIFF
--- a/example/greet.hs
+++ b/example/greet.hs
@@ -66,11 +66,11 @@ intro2 = DocIntro "This title is below the last"
 -- API specification
 type TestApi =
        -- GET /hello/:name?capital={true, false}  returns a Greet as JSON
-       "hello" :> MatrixParam "lang" String :> Capture "name" Text :> QueryParam "capital" Bool :> Get Greet
+       "hello" :> MatrixParam "lang" String :> Capture "name" Text :> QueryParam "capital" Bool :> Get '[JSON] Greet
 
        -- POST /greet with a Greet as JSON in the request body,
        --             returns a Greet as JSON
-  :<|> "greet" :> ReqBody Greet :> Post Greet
+  :<|> "greet" :> ReqBody '[JSON] Greet :> Post '[JSON] Greet
 
        -- DELETE /greet/:greetid
   :<|> "greet" :> Capture "greetid" Text :> Delete

--- a/servant-docs.cabal
+++ b/servant-docs.cabal
@@ -29,14 +29,12 @@ library
   build-depends:
       base >=4.7 && <5
     , aeson
-    , aeson-pretty < 0.8
     , bytestring
     , hashable
     , http-media
     , lens
     , servant >= 0.2.1
     , string-conversions
-    , system-filepath
     , text
     , unordered-containers
   hs-source-dirs: src

--- a/servant-docs.cabal
+++ b/servant-docs.cabal
@@ -32,6 +32,7 @@ library
     , aeson-pretty < 0.8
     , bytestring
     , hashable
+    , http-media
     , lens
     , servant >= 0.2.1
     , string-conversions
@@ -46,5 +47,5 @@ executable greet-docs
   main-is: greet.hs
   hs-source-dirs: example
   ghc-options: -Wall
-  build-depends: base, aeson, servant, servant-docs, text
+  build-depends: base, aeson, aeson-pretty, servant, servant-docs, text
   default-language: Haskell2010

--- a/src/Servant/Docs.hs
+++ b/src/Servant/Docs.hs
@@ -102,11 +102,11 @@
 -- > -- API specification
 -- > type TestApi =
 -- >        -- GET /hello/:name?capital={true, false}  returns a Greet as JSON
--- >        "hello" :> MatrixParam "lang" String :> Capture "name" Text :> QueryParam "capital" Bool :> Get Greet
+-- >        "hello" :> MatrixParam "lang" String :> Capture "name" Text :> QueryParam "capital" Bool :> Get '[JSON] Greet
 -- >
 -- >        -- POST /greet with a Greet as JSON in the request body,
 -- >        --             returns a Greet as JSON
--- >   :<|> "greet" :> ReqBody Greet :> Post Greet
+-- >   :<|> "greet" :> ReqBody '[JSON] Greet :> Post '[JSON] Greet
 -- >
 -- >        -- DELETE /greet/:greetid
 -- >   :<|> "greet" :> Capture "greetid" Text :> Delete
@@ -154,7 +154,7 @@ module Servant.Docs
   , module Data.Monoid
   ) where
 
-import Control.Lens hiding (Action)
+import Control.Lens
 import Data.Aeson
 import Data.Aeson.Encode.Pretty (encodePretty)
 import Data.Ord(comparing)
@@ -641,7 +641,7 @@ instance HasDocs Delete where
           action' = action & response.respBody .~ []
                            & response.respStatus .~ 204
 
-instance ToSample a => HasDocs (Get a) where
+instance ToSample a => HasDocs (Get cts a) where
   docsFor Proxy (endpoint, action) =
     single endpoint' action'
 
@@ -658,7 +658,7 @@ instance (KnownSymbol sym, HasDocs sublayout)
           action' = over headers (|> headername) action
           headername = pack $ symbolVal (Proxy :: Proxy sym)
 
-instance ToSample a => HasDocs (Post a) where
+instance ToSample a => HasDocs (Post cts a) where
   docsFor Proxy (endpoint, action) =
     single endpoint' action'
 
@@ -669,7 +669,7 @@ instance ToSample a => HasDocs (Post a) where
 
           p = Proxy :: Proxy a
 
-instance ToSample a => HasDocs (Put a) where
+instance ToSample a => HasDocs (Put cts a) where
   docsFor Proxy (endpoint, action) =
     single endpoint' action'
 
@@ -761,7 +761,7 @@ instance HasDocs Raw where
     single endpoint action
 
 instance (ToSample a, HasDocs sublayout)
-      => HasDocs (ReqBody a :> sublayout) where
+      => HasDocs (ReqBody cts a :> sublayout) where
 
   docsFor Proxy (endpoint, action) =
     docsFor sublayoutP (endpoint, action')


### PR DESCRIPTION
Done:

- Generated documentation includes sample request and response bodies encoded in supported content types.

Todo:

- Generated documentation lists supported content types for request and response bodies.